### PR TITLE
Update to correctly set background for amethyst-dark gnome-shell

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,7 +103,7 @@ install() {
   cp -r ${SRC_DIR}/gnome-shell/color-assets/toggle-on${theme}.svg                       ${THEME_DIR}/gnome-shell/assets/toggle-on.svg
   cp -r ${SRC_DIR}/gnome-shell/color-assets/menu-checked${theme}.svg                    ${THEME_DIR}/gnome-shell/assets/menu-checked.svg
 
-  if [[ ${theme} == '-doder' && ${color} == '-dark' ]] || [[ ${theme} == '-beryl' && ${color} == '-dark' ]]; then
+  if [[ ${theme} == '-doder' && ${color} == '-dark' ]] || [[ ${theme} == '-beryl' && ${color} == '-dark' ]] || [[ ${theme} == '-amethyst' && ${color} == '-dark' ]]; then
     cp -r ${SRC_DIR}/gnome-shell/color-assets/menu-doder.svg                            ${THEME_DIR}/gnome-shell/assets/menu.svg
   fi
 


### PR DESCRIPTION
install.sh has been updated to install the correct background file for the amethyst dark theme in gnome shell.

This should fix #177 .