### PR TITLE
Fix image-button styling (fixes #186)

### DIFF
--- a/src/gtk-3.0/sass/_common.scss
+++ b/src/gtk-3.0/sass/_common.scss
@@ -458,13 +458,17 @@ treeview entry {
   }
 }
 
-%flat_button {
+@mixin -flat_button {
   @include button(flat-normal);
   &:hover { @include button(flat-hover); }
   &:active { @include button(flat-active); }
   &:disabled { @include button(flat-disabled); }
   &:checked { @include button(flat-checked); }
   &:checked:disabled { @include button(flat-checked-disabled); }
+}
+
+%flat_button {
+  @include -flat-button;
 }
 
 %simple_flat_button {
@@ -749,7 +753,7 @@ button {
 toolbutton {
   button,
   button.image-button,
-  button.image-button.toggle { @extend %flat_button; } // Use flat button for all toolbuttons
+  button.image-button.toggle { @include -flat_button; } // Use flat button for all toolbuttons
 }
 
 // all the following is for the +|- buttons on inline toolbars, that way


### PR DESCRIPTION
Seemingly due to Sass having a hard time processing nested placeholder
selectors, the styling for `toolbutton button.image-button` and
for `toolbutton button.image-button.toggle` did not get their
`:hover`, `:active`, `:disabled`, `:checked`, and `:checked:disabled`
styles applied.

As a workaround, I extracted the style for the `%flat_button`
placeholder selector into a mixin, and used the mixing to style
`toolbutton button`. This increases the compiled CSS size by a
negligible amount, while allowing the image toolbar buttons to be styled
correctly according to their state.

I am unsure whether this is Sass bug, but maybe we should investigate further.