### PR TITLE
Fix MATE panel in light theme

### DIFF
--- a/src/gtk-3.0/gtk-light-amethyst.css
+++ b/src/gtk-3.0/gtk-light-amethyst.css
@@ -6930,8 +6930,8 @@ menuitem calendar .view {
 
 #PanelPlug,
 PanelToplevel.background {
-  background-color: #212329;
-  color: #FFFFFF;
+  background-color: #f4f5f6;
+  color: rgba(0, 0, 0, 0.8);
   font-weight: 500;
 }
 

--- a/src/gtk-3.0/gtk-light-beryl.css
+++ b/src/gtk-3.0/gtk-light-beryl.css
@@ -6930,8 +6930,8 @@ menuitem calendar .view {
 
 #PanelPlug,
 PanelToplevel.background {
-  background-color: #212329;
-  color: #FFFFFF;
+  background-color: #f4f5f6;
+  color: rgba(0, 0, 0, 0.8);
   font-weight: 500;
 }
 

--- a/src/gtk-3.0/gtk-light-doder.css
+++ b/src/gtk-3.0/gtk-light-doder.css
@@ -6930,8 +6930,8 @@ menuitem calendar .view {
 
 #PanelPlug,
 PanelToplevel.background {
-  background-color: #212329;
-  color: #FFFFFF;
+  background-color: #f4f5f6;
+  color: rgba(0, 0, 0, 0.8);
   font-weight: 500;
 }
 

--- a/src/gtk-3.0/gtk-light-laptop-amethyst.css
+++ b/src/gtk-3.0/gtk-light-laptop-amethyst.css
@@ -6930,8 +6930,8 @@ menuitem calendar .view {
 
 #PanelPlug,
 PanelToplevel.background {
-  background-color: #212329;
-  color: #FFFFFF;
+  background-color: #f4f5f6;
+  color: rgba(0, 0, 0, 0.8);
   font-weight: 500;
 }
 

--- a/src/gtk-3.0/gtk-light-laptop-beryl.css
+++ b/src/gtk-3.0/gtk-light-laptop-beryl.css
@@ -6930,8 +6930,8 @@ menuitem calendar .view {
 
 #PanelPlug,
 PanelToplevel.background {
-  background-color: #212329;
-  color: #FFFFFF;
+  background-color: #f4f5f6;
+  color: rgba(0, 0, 0, 0.8);
   font-weight: 500;
 }
 

--- a/src/gtk-3.0/gtk-light-laptop-doder.css
+++ b/src/gtk-3.0/gtk-light-laptop-doder.css
@@ -6930,8 +6930,8 @@ menuitem calendar .view {
 
 #PanelPlug,
 PanelToplevel.background {
-  background-color: #212329;
-  color: #FFFFFF;
+  background-color: #f4f5f6;
+  color: rgba(0, 0, 0, 0.8);
   font-weight: 500;
 }
 

--- a/src/gtk-3.0/gtk-light-laptop-ruby.css
+++ b/src/gtk-3.0/gtk-light-laptop-ruby.css
@@ -6930,8 +6930,8 @@ menuitem calendar .view {
 
 #PanelPlug,
 PanelToplevel.background {
-  background-color: #222222;
-  color: #FFFFFF;
+  background-color: #f1f1f1;
+  color: rgba(0, 0, 0, 0.8);
   font-weight: 500;
 }
 

--- a/src/gtk-3.0/gtk-light-laptop.css
+++ b/src/gtk-3.0/gtk-light-laptop.css
@@ -6930,8 +6930,8 @@ menuitem calendar .view {
 
 #PanelPlug,
 PanelToplevel.background {
-  background-color: #222222;
-  color: #FFFFFF;
+  background-color: #f1f1f1;
+  color: rgba(0, 0, 0, 0.8);
   font-weight: 500;
 }
 

--- a/src/gtk-3.0/gtk-light-ruby.css
+++ b/src/gtk-3.0/gtk-light-ruby.css
@@ -6930,8 +6930,8 @@ menuitem calendar .view {
 
 #PanelPlug,
 PanelToplevel.background {
-  background-color: #222222;
-  color: #FFFFFF;
+  background-color: #f1f1f1;
+  color: rgba(0, 0, 0, 0.8);
   font-weight: 500;
 }
 

--- a/src/gtk-3.0/gtk-light.css
+++ b/src/gtk-3.0/gtk-light.css
@@ -6930,8 +6930,8 @@ menuitem calendar .view {
 
 #PanelPlug,
 PanelToplevel.background {
-  background-color: #222222;
-  color: #FFFFFF;
+  background-color: #f1f1f1;
+  color: rgba(0, 0, 0, 0.8);
   font-weight: 500;
 }
 


### PR DESCRIPTION
Commit 63bdb94 unified the MATE panel colors between regular, light, and dark variants, making the grey color in the regular theme a bit darker, and the nearly-white color in the light theme much darker. The light theme has looked fugly on MATE desktop ever since. This should fix it.

Before: 
![mate-panel-fix-before](https://user-images.githubusercontent.com/93612/113901389-cd4d0000-979c-11eb-8541-61392fca161f.png)
After: 
![mate-panel-fix-after](https://user-images.githubusercontent.com/93612/113901425-d50ca480-979c-11eb-8783-2c8bd4a7d6f8.png)

