### PR TITLE
Make `pacman` install `sassc` as a dependency

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -413,7 +413,7 @@ install_package() {
     elif has_command dnf; then
       sudo dnf install sassc
     elif has_command pacman; then
-      sudo pacman -S --noconfirm sassc
+      sudo pacman -S --noconfirm --asdeps sassc
     fi
   fi
 }


### PR DESCRIPTION
Users probably do not want the package to be explicitly installed.
Arch build system has a concept of make dependencies, so they can easily be cleaned up after the build.