### PR TITLE
Fix typo: filder -> filter

### DIFF
--- a/src/_sass/gtk/_common-4.0.scss
+++ b/src/_sass/gtk/_common-4.0.scss
@@ -4581,7 +4581,7 @@ scrolledwindow {
   }
 
   .top-bar > windowhandle:backdrop {
-    filder: none;
+    filter: none;
   }
 }
 
@@ -4610,7 +4610,7 @@ $tabbar_shadow_dark: inset 0 2px 3px -2px rgba(black, 0.2),
   }
 
   > windowhandle:backdrop {
-    filder: none;
+    filter: none;
   }
 }
 

--- a/src/gtk/4.0/gtk-dark.css
+++ b/src/gtk/4.0/gtk-dark.css
@@ -5503,7 +5503,7 @@ scrolledwindow.undershoot-end:dir(rtl) > undershoot.left {
 
 .sidebar-pane .top-bar > windowhandle:backdrop,
 .content-pane .top-bar > windowhandle:backdrop {
-  filder: none;
+  filter: none;
 }
 
 .top-bar {
@@ -5521,7 +5521,7 @@ scrolledwindow.undershoot-end:dir(rtl) > undershoot.left {
 }
 
 .top-bar > windowhandle:backdrop {
-  filder: none;
+  filter: none;
 }
 
 .bottom-bar {

--- a/src/gtk/4.0/gtk-light.css
+++ b/src/gtk/4.0/gtk-light.css
@@ -5503,7 +5503,7 @@ scrolledwindow.undershoot-end:dir(rtl) > undershoot.left {
 
 .sidebar-pane .top-bar > windowhandle:backdrop,
 .content-pane .top-bar > windowhandle:backdrop {
-  filder: none;
+  filter: none;
 }
 
 .top-bar {
@@ -5521,7 +5521,7 @@ scrolledwindow.undershoot-end:dir(rtl) > undershoot.left {
 }
 
 .top-bar > windowhandle:backdrop {
-  filder: none;
+  filter: none;
 }
 
 .bottom-bar {

--- a/src/gtk/4.0/gtk.css
+++ b/src/gtk/4.0/gtk.css
@@ -5502,7 +5502,7 @@ scrolledwindow.undershoot-end:dir(rtl) > undershoot.left {
 
 .sidebar-pane .top-bar > windowhandle:backdrop,
 .content-pane .top-bar > windowhandle:backdrop {
-  filder: none;
+  filter: none;
 }
 
 .top-bar {
@@ -5520,7 +5520,7 @@ scrolledwindow.undershoot-end:dir(rtl) > undershoot.left {
 }
 
 .top-bar > windowhandle:backdrop {
-  filder: none;
+  filter: none;
 }
 
 .bottom-bar {


### PR DESCRIPTION
Fixes a warning I experienced working on a GTK4 ags status bar here:
`(gjs:401652): Gtk-WARNING **: 14:40:53.185: Theme parser error: gtk-dark.css:5506:3-9: No property named "filder"`