### PR TITLE
Fix junk at end of value for outline width

### DIFF
--- a/src/_sass/gtk/_apps-4.0.scss
+++ b/src/_sass/gtk/_apps-4.0.scss
@@ -519,7 +519,7 @@ preferencesgroup > box {
     padding: 0;
     background: none;
     box-shadow: none;
-    outline-width: 2px solid transparent;
+    outline: 2px solid transparent;
     outline-offset: $space_size / 2;
 
     &, > background-preview {

--- a/src/gtk/4.0/gtk-dark.css
+++ b/src/gtk/4.0/gtk-dark.css
@@ -6914,7 +6914,7 @@ preferencesgroup > box button.background-preview-button.toggle {
   padding: 0;
   background: none;
   box-shadow: none;
-  outline-width: 2px solid transparent;
+  outline: 2px solid transparent;
   outline-offset: 3px;
 }
 

--- a/src/gtk/4.0/gtk-light.css
+++ b/src/gtk/4.0/gtk-light.css
@@ -6914,7 +6914,7 @@ preferencesgroup > box button.background-preview-button.toggle {
   padding: 0;
   background: none;
   box-shadow: none;
-  outline-width: 2px solid transparent;
+  outline: 2px solid transparent;
   outline-offset: 3px;
 }
 

--- a/src/gtk/4.0/gtk.css
+++ b/src/gtk/4.0/gtk.css
@@ -6928,7 +6928,7 @@ preferencesgroup > box button.background-preview-button.toggle {
   padding: 0;
   background: none;
   box-shadow: none;
-  outline-width: 2px solid transparent;
+  outline: 2px solid transparent;
   outline-offset: 3px;
 }
 


### PR DESCRIPTION
Fixes warning I experienced working on GTK4 ags status bar:
`(gjs:401652): Gtk-WARNING **: 14:40:53.175: Theme parser error: gtk.css:6917:22-27: Junk at end of value for outline-width`

I'm guessing that `outline-width: 2px solid transparent;` was intended to be `outline: 2px solid transparent;` given the selectors listed next look like this:
```sass
    &:hover {
      outline: 2px solid $divider;
    }

    &:active {
      outline: 2px solid $track;
    }

    &:checked {
      outline: 2px solid $primary;
    }
```