### PR TITLE
Fix metacity titlebar padding for Vimix and Vimix_dark variants

### DIFF
--- a/src/metacity-1/metacity-theme-3.xml
+++ b/src/metacity-1/metacity-theme-3.xml
@@ -4,7 +4,7 @@
 	<name>Vimix</name>
 	<author>Vince Liuice</author>
 	<copyright>GPL-3.0+</copyright>
-	<date>2018.8.28</date>
+	<date>2024.5.01</date>
 	<description>Vimix Metacity Theme</description>
 </info>
 
@@ -19,27 +19,27 @@
 
 <!-- Focused window -->
 <frame_geometry name="normal" title_scale="medium" rounded_top_left="2" rounded_top_right="2">
-	<distance name="left_width" value="2" />
-	<distance name="right_width" value="2" />
-	<distance name="bottom_height" value="2" />
-	<distance name="left_titlebar_edge" value="8" />
+	<distance name="left_width" value="1" />
+	<distance name="right_width" value="1" />
+	<distance name="bottom_height" value="1" />
+	<distance name="left_titlebar_edge" value="10" />
 	<distance name="right_titlebar_edge" value="0" />
-	<distance name="title_vertical_pad" value="12" />
+	<distance name="title_vertical_pad" value="4" />
 	<aspect_ratio name="button" value="1.0" />
-	<border name="title_border" left="10" right="10" top="4" bottom="0" />
-	<border name="button_border" left="0" right="0" top="6" bottom="0" />
+	<border name="title_border" left="4" right="4" top="4" bottom="4" />
+	<border name="button_border" left="0" right="0" top="4" bottom="4" />
 </frame_geometry>
 
 <!-- Unfocused window -->
 <frame_geometry name="normal_unfocused" title_scale="medium" rounded_top_left="2" rounded_top_right="2" parent="normal" >
-	<distance name="left_width" value="2" />
-	<distance name="right_width" value="2" />
-	<distance name="bottom_height" value="2" />
-	<distance name="left_titlebar_edge" value="8"/>
+	<distance name="left_width" value="1" />
+	<distance name="right_width" value="1" />
+	<distance name="bottom_height" value="1" />
+	<distance name="left_titlebar_edge" value="10"/>
 	<distance name="right_titlebar_edge" value="0"/>
-	<distance name="title_vertical_pad" value="12" />
-	<border name="title_border" left="10" right="10" top="4" bottom="0" />
-	<border name="button_border" left="0" right="0" top="6" bottom="0" />
+	<distance name="title_vertical_pad" value="4" />
+	<border name="title_border" left="4" right="4" top="4" bottom="4" />
+	<border name="button_border" left="0" right="0" top="4" bottom="4" />
 </frame_geometry>
 
 <!-- Maximized window -->
@@ -47,6 +47,9 @@
 	<distance name="left_width" value="0" />
 	<distance name="right_width" value="0" />
 	<distance name="bottom_height" value="0" />
+	<distance name="title_vertical_pad" value="4" />
+	<border name="title_border" left="4" right="4" top="4" bottom="4" />
+	<border name="button_border" left="0" right="0" top="4" bottom="4" />
 </frame_geometry>
 
 <!-- Left tiled window -->
@@ -60,80 +63,67 @@
 </frame_geometry>
 
 <!-- Small window -->
-<frame_geometry name="small" title_scale="small" parent="normal" rounded_top_left="2" rounded_top_right="2">
+<frame_geometry name="small" title_scale="small" parent="normal" rounded_top_left="false" rounded_top_right="false">
 	<distance name="title_vertical_pad" value="4" />
-	<distance name="left_titlebar_edge" value="0"/>
-	<distance name="right_titlebar_edge" value="0"/>
 	<border name="title_border" left="4" right="4" top="0" bottom="0" />
 	<border name="button_border" left="0" right="0" top="0" bottom="0"  />
 </frame_geometry>
 
 <!-- Small unfocused window -->
 <frame_geometry name="small_unfocused" parent="small">
+	<distance name="left_titlebar_edge" value="4"/>
+	<distance name="right_titlebar_edge" value="4"/>
 </frame_geometry>
 
 <!-- No buttons -->
 <frame_geometry name="nobuttons" hide_buttons="true" parent="normal">
-	<border name="title_border" left="0" right="0" top="0" bottom="0" />
-	<border name="button_border" left="0" right="0" top="0" bottom="0"  />
 </frame_geometry>
 
 <!-- Border -->
-<frame_geometry name="border" has_title="false" rounded_top_left="2" rounded_top_right="2" parent="normal" >
+<frame_geometry name="border" has_title="false" rounded_top_left="false" rounded_top_right="false" parent="normal" >
 	<distance name="left_width" value="0" />
 	<distance name="right_width" value="0" />
 	<distance name="bottom_height" value="0" />
-	<distance name="title_vertical_pad" value="0" />
-	<border name="title_border" left="12" right="12" top="0" bottom="0" />
+	<distance name="title_vertical_pad" value="1" />
+	<border name="title_border" left="10" right="10" top="0" bottom="0" />
 	<border name="button_border" left="0" right="0" top="0" bottom="0"/>
 </frame_geometry>
 
 <!-- Borderless -->
-<frame_geometry name="borderless" has_title="false" rounded_top_left="2" rounded_top_right="2" parent="normal">
+<frame_geometry name="borderless" has_title="false" rounded_top_left="false" rounded_top_right="false" parent="normal">
 	<distance name="left_width" value="0" />
 	<distance name="right_width" value="0" />
 	<distance name="bottom_height" value="0" />
-	<distance name="title_vertical_pad" value="0" />
-	<border name="title_border" left="12" right="12" top="0" bottom="0" />
+	<distance name="title_vertical_pad" value="8" />
+	<border name="title_border" left="0" right="0" top="0" bottom="0" />
 	<border name="button_border" left="0" right="0" top="0" bottom="0" />
 </frame_geometry>
 
 <!-- Modal -->
-<frame_geometry name="modal" title_scale="small" hide_buttons="true" rounded_top_left="2" rounded_top_right="2" parent="small">
-	<distance name="title_vertical_pad" value="4"/>
+<frame_geometry name="modal" title_scale="small" hide_buttons="true" rounded_top_left="false" rounded_top_right="false" parent="small">
+	<distance name="title_vertical_pad" value="5"/>
 </frame_geometry>
 
-<!--chromium save dialog-->
-<frame_geometry name="attached" title_scale="small" has_title="false"  hide_buttons="true" rounded_top_left="0" rounded_top_right="0" rounded_bottom_left="0" rounded_bottom_right="0" parent="normal">
-	<distance name="title_vertical_pad" value="0"/>
-	<distance name="bottom_height" value="0"/>
-	<distance name="left_width" value="0"/>
-	<distance name="right_width" value="0"/>
+<frame_geometry name="attached" title_scale="medium" hide_buttons="true" rounded_top_left="false" rounded_top_right="false" parent="normal">
+	<distance name="title_vertical_pad" value="8"/>
+	<distance name="bottom_height" value="1"/>
+	<distance name="left_width" value="1"/>
+	<distance name="right_width" value="1"/>
 </frame_geometry>
+
 
 <!-- TITLES -->
 
+<!-- Title alignment -->
 <draw_ops name="title_focused">
-	<title version="< 3.1"
-               x="(0 `max` ((width - title_width) / 2))"
-               y="(0 `max` ((height - title_height) / 2)) + 1"
-               color="C_title_focused" />
-	<title version=">= 3.1"
-               x="(0 `max` ((frame_x_center - title_width / 2) `min` (width - title_width)))"
-               y="(0 `max` ((height - title_height) / 2)) + 1"
-               ellipsize_width="width"
+	<title x="(0 `max` ((width - title_width) / 2)) + 2"
+               y="(0 `max` ((height - title_height) / 2))"
                color="C_title_focused" />
 </draw_ops>
 
 <draw_ops name="title_unfocused">
-	<title version="< 3.1"
-               x="(0 `max` ((width - title_width) / 2))"
-               y="(0 `max` ((height - title_height) / 2)) + 1"
-               color="C_title_unfocused" />
-	<title version=">= 3.1"
-               x="(0 `max` ((frame_x_center - title_width / 2) `min` (width - title_width)))"
-               y="(0 `max` ((height - title_height) / 2)) + 1"
-               ellipsize_width="width"
+	<title x="(0 `max` ((width - title_width) / 2)) + 2"
+               y="(0 `max` ((height - title_height) / 2))"
                color="C_title_unfocused" />
 </draw_ops>
 


### PR DESCRIPTION
In the metacity theme's dark variants the titlebar is taller and the title string is vertically off-center.
I just merged the padding and alignment settings from the light variant to fix this.
![Schermata su 2025-05-01 09-52-26](https://github.com/user-attachments/assets/3bbaa524-86a7-4c87-ae3b-9706a5267a89)
![Schermata su 2025-05-01 09-59-00](https://github.com/user-attachments/assets/30aa08f4-e8c1-49b2-b705-e10bcd885dfd)
